### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-blue-grass-0e94fb21e.yml
+++ b/.github/workflows/azure-static-web-apps-blue-grass-0e94fb21e.yml
@@ -1,5 +1,9 @@
 name: Azure Static Web Apps CI/CD
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/vedantgrover/VedantsPortfolio/security/code-scanning/2](https://github.com/vedantgrover/VedantsPortfolio/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for PR-related actions (e.g., comments or status updates).

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
